### PR TITLE
docs(readme): README 加入一键复制 AI Agent 提示词块

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,114 @@
 
 ---
 
+## 📋 One-Click Copy for AI Agents
+
+Copy the prompt below and paste it into your AI agent (Claude Code, Cursor, Windsurf, ChatGPT, etc.). The agent will follow the instructions to install and use NPM Skills automatically — no need to explain commands line by line.
+
+<details>
+<summary><b>📋 Click to expand the full AI agent prompt</b></summary>
+
+````md
+---
+title: Use NPM Skills to operate on the NPM Registry
+---
+
+# Your Task
+
+You now have access to **NPM Skills** — a complete NPM Registry client supporting package query, version management, dist-tags, download stats, publishing, access control, security audit, org/team, webhooks, etc. Includes 8 mirrors (China: no proxy needed) and HTTP/SOCKS5 proxy support.
+
+## Step 1: Install (pick one based on your environment; option 1 recommended)
+
+### Option 1: Claude Code plugin (AI-native, recommended)
+```bash
+claude plugin marketplace add scagogogo/npm-skills
+claude plugin install npm@npm-skills
+```
+After install, you (AI) auto-discover SKILL.md and invoke on demand — no manual shell needed.
+
+### Option 2: Download prebuilt binary (without Claude Code)
+```bash
+# Linux x86_64
+curl -sL https://github.com/scagogogo/npm-skills/releases/latest/download/npm-skills_0.2.0_linux_x86_64.tar.gz | tar -xz
+sudo mv npm-skills npm-mcp-server /usr/local/bin/
+# macOS Apple Silicon: replace linux_x86_64 with aarch64; Windows: use .zip
+```
+
+### Option 3: Build from source
+```bash
+bash scripts/install.sh   # Compiles to ~/.local/bin/
+```
+
+### Option 4: go install
+```bash
+go install github.com/scagogogo/npm-skills/cmd/npm-skills@latest
+go install github.com/scagogogo/npm-skills/cmd/mcp-server@latest
+```
+
+## Step 2: Verify installation
+```bash
+npm-skills --version
+npm-skills mirrors          # List 8 mirror sources
+```
+
+## Step 3: Common commands cheat sheet (90% of cases)
+
+### Get package info
+```bash
+npm-skills package-summary <name>        # Lightweight (recommended, KB response)
+npm-skills package <name>                # Full metadata (can be 10MB+)
+npm-skills versions <name> --latest      # Latest version
+npm-skills pkg-version <name> <ver>      # Specific version details
+```
+
+### Search and stats
+```bash
+npm-skills search "<query>" -l 10                  # Search packages
+npm-skills download-stats <name> -p last-month    # Download count
+npm-skills download-range <name> -p last-week     # Daily trend
+npm-skills download-stats-bulk react,vue -p last-month  # Bulk compare
+```
+
+### Mirrors and proxy (China users: key section)
+```bash
+npm-skills package react -m npm-mirror                              # China mirror, no proxy
+npm-skills package react --proxy http://127.0.0.1:7890              # HTTP proxy
+npm-skills package my-lib --registry https://npm.my-company.com     # Private registry
+```
+Env vars: `NPM_MIRROR=npm-mirror`, `NPM_PROXY=...`, `NPM_TOKEN=...`
+
+### Write operations (require token)
+```bash
+npm-skills publish ./pkg.tgz --name my-pkg --version 1.0.0 -t npm_xxxxx
+npm-skills deprecate my-pkg 1.0.0 -M "Use v2.0.0" -t npm_xxxxx
+npm-skills dist-tags set my-pkg next --version 2.0.0-rc.1 -t npm_xxxxx
+npm-skills access get my-pkg -t npm_xxxxx
+npm-skills audit quick --deps "lodash=4.17.11,express=4.17.1"
+```
+
+## Key rules
+1. **All commands output JSON to stdout**; status/info goes to stderr — parse with `jq`.
+2. **Read ops = no auth**; write ops need `--token` or `NPM_TOKEN`. Verify with `whoami`.
+3. **Prefer `package-summary`** over `package` — smaller, faster.
+4. **Download stats always query api.npmjs.org** regardless of mirror.
+5. China users: default to `-m npm-mirror`; restricted networks: add `--proxy`; private registries: `--registry`.
+6. Typed errors: `ErrNotFound`/`ErrUnauthorized`/`ErrRateLimited` for programmatic handling.
+
+## When the user asks for NPM-related tasks
+Pick the matching command and run:
+- "Check axios info" → `npm-skills package-summary axios`
+- "React downloads last month" → `npm-skills download-stats react -p last-month`
+- "Query vue via China mirror" → `npm-skills package vue -m npm-mirror`
+- "Publish my package" → `npm-skills publish ... -t $NPM_TOKEN`
+- "Audit dependencies" → `npm-skills audit quick --deps "..."`
+
+Full 26 commands: `npm-skills --help`. SDK docs: https://scagogogo.github.io/npm-skills/en/api/
+````
+
+</details>
+
+---
+
 ## ⚡ One-Click Plugin Install
 
 Install as a Claude Code plugin — AI agents will automatically discover and use it:

--- a/README_zh.md
+++ b/README_zh.md
@@ -34,6 +34,114 @@
 
 ---
 
+## 📋 一键复制给 AI Agent
+
+把下面这段提示词复制粘贴给你的 AI Agent（Claude Code、Cursor、Windsurf、ChatGPT 等），Agent 会顺着指引自动安装并使用 NPM Skills，无需你逐条解释命令：
+
+<details>
+<summary><b>📋 点击展开完整的 AI Agent 提示词</b></summary>
+
+````md
+---
+title: 使用 NPM Skills 操作 NPM Registry
+---
+
+# 你的任务
+
+你现在可以使用 **NPM Skills** —— 一个完整的 NPM Registry 客户端，支持包查询、版本管理、dist-tags、下载统计、发布、访问控制、安全审计、组织/团队、webhooks 等，内置 8 个镜像源（中国大陆免代理）与 HTTP/SOCKS5 代理。
+
+## 第一步：安装（按你的环境任选一种，推荐方式 1）
+
+### 方式 1：作为 Claude Code 插件（AI 原生，推荐）
+```bash
+claude plugin marketplace add scagogogo/npm-skills
+claude plugin install npm@npm-skills
+```
+安装后你（AI）会自动发现 SKILL.md 并按需调用，无需手动 shell。
+
+### 方式 2：下载预编译二进制（无 Claude Code 时）
+```bash
+# Linux x86_64
+curl -sL https://github.com/scagogogo/npm-skills/releases/latest/download/npm-skills_0.2.0_linux_x86_64.tar.gz | tar -xz
+sudo mv npm-skills npm-mcp-server /usr/local/bin/
+# macOS Apple Silicon：把 linux_x86_64 换成 aarch64；Windows 用 zip 包
+```
+
+### 方式 3：从源码构建
+```bash
+bash scripts/install.sh   # 编译到 ~/.local/bin/
+```
+
+### 方式 4：go install
+```bash
+go install github.com/scagogogo/npm-skills/cmd/npm-skills@latest
+go install github.com/scagogogo/npm-skills/cmd/mcp-server@latest
+```
+
+## 第二步：验证安装
+```bash
+npm-skills --version
+npm-skills mirrors          # 列出 8 个镜像源
+```
+
+## 第三步：常用命令速查（90% 场景）
+
+### 查包信息
+```bash
+npm-skills package-summary <name>        # 轻量（推荐，KB 级响应）
+npm-skills package <name>                # 完整元数据（可能 10MB+）
+npm-skills versions <name> --latest      # 最新版本
+npm-skills pkg-version <name> <ver>      # 特定版本详情
+```
+
+### 搜索与统计
+```bash
+npm-skills search "<query>" -l 10                  # 搜索包
+npm-skills download-stats <name> -p last-month    # 下载量
+npm-skills download-range <name> -p last-week     # 每日趋势
+npm-skills download-stats-bulk react,vue -p last-month  # 批量对比
+```
+
+### 镜像与代理（中国大陆用户重点）
+```bash
+npm-skills package react -m npm-mirror                              # 国内镜像，免代理
+npm-skills package react --proxy http://127.0.0.1:7890              # HTTP 代理
+npm-skills package my-lib --registry https://npm.my-company.com     # 私有仓库
+```
+环境变量：`NPM_MIRROR=npm-mirror`、`NPM_PROXY=...`、`NPM_TOKEN=...`
+
+### 写操作（需要 token）
+```bash
+npm-skills publish ./pkg.tgz --name my-pkg --version 1.0.0 -t npm_xxxxx
+npm-skills deprecate my-pkg 1.0.0 -M "Use v2.0.0" -t npm_xxxxx
+npm-skills dist-tags set my-pkg next --version 2.0.0-rc.1 -t npm_xxxxx
+npm-skills access get my-pkg -t npm_xxxxx
+npm-skills audit quick --deps "lodash=4.17.11,express=4.17.1"
+```
+
+## 关键规则
+1. **所有命令输出 JSON 到 stdout**，状态信息走 stderr —— 你可以用 `jq` 解析。
+2. **读取操作免认证**；写入操作必须 `--token` 或 `NPM_TOKEN`。用 `whoami` 验证。
+3. **优先 `package-summary`** 而非 `package`，响应小、快。
+4. **下载统计始终查 api.npmjs.org**，与镜像设置无关。
+5. 中国大陆用户默认 `-m npm-mirror`；受限网络叠 `--proxy`；私有仓库用 `--registry`。
+6. 类型化错误：`ErrNotFound`/`ErrUnauthorized`/`ErrRateLimited` 等，可程序化处理。
+
+## 当用户提出 NPM 相关需求时
+直接选对应命令执行，例如：
+- "查 axios 信息" → `npm-skills package-summary axios`
+- "react 上个月下载量" → `npm-skills download-stats react -p last-month`
+- "国内镜像查 vue" → `npm-skills package vue -m npm-mirror`
+- "发布我的包" → `npm-skills publish ... -t $NPM_TOKEN`
+- "审计依赖安全" → `npm-skills audit quick --deps "..."`
+
+完整 26 命令见 `npm-skills --help`，SDK 文档见 https://scagogogo.github.io/npm-skills/api/
+````
+
+</details>
+
+---
+
 ## ⚡ 一键安装 Plugin
 
 安装为 Claude Code 插件 — AI 智能体会自动发现并使用它：


### PR DESCRIPTION
## 改动内容

在 README.md 和 README_zh.md 的架构图之后、One-Click Plugin Install 章节之前，插入与[首页](https://scagogogo.github.io/npm-skills/)完全一致的"一键复制给 AI Agent"提示词块。

## 背景
README 是 GitHub 仓库门面，很多用户/Agent 从这里进入。首页已有提示词块（PR #3），但 README 没有对称入口。补充后，从 GitHub 进入的用户也能一键投喂提示词给 AI Agent。

## 实现
- 用 `<details>` 折叠（默认收起，避免占据太多首屏空间）
- 内部 4 反引号 `md` 围栏包裹完整提示词（任务/安装 1-4/验证/命令速查/关键规则/当用户提出 NPM 需求时）
- 内容与 `website/index.md`、`website/en/index.md` 对齐

## 验证
- 4 反引号围栏正确配对（开 ````md / 闭 ````）
- 中英文内容关键词齐全（Your Task/你的任务、package-summary、claude plugin marketplace）

🤖 Generated with [Claude Code](https://claude.com/claude-code)